### PR TITLE
Add .srm file support and preserve PC box state after saving

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -329,7 +329,7 @@ def load_databases():
 
 @app.post("/upload")
 async def upload_save(file: UploadFile = File(...)):
-    """Load the .sav file into memory."""
+    """Load the .sav or .srm file into memory."""
     content = await file.read()
     current_save["data"] = bytearray(content)
     current_save["filename"] = file.filename

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -15,6 +15,7 @@ const App = () => {
     const [runtimeMode, setRuntimeMode] = useState(getInitialRuntimeMode);
     const [activeTab, setActiveTab] = useState('party');
     const [isLoaded, setIsLoaded] = useState(false);
+    const [saveExt, setSaveExt] = useState('.sav');
     const [money, setMoney] = useState(0);
     const [showMoneyModal, setShowMoneyModal] = useState(false);
     const [moneyInput, setMoneyInput] = useState('0');
@@ -32,6 +33,7 @@ const App = () => {
             const mData = await client.getMoney();
             setMoney(mData.money);
             setMoneyInput(String(mData.money ?? 0));
+            setSaveExt(file.name.toLowerCase().endsWith('.srm') ? '.srm' : '.sav');
             setIsLoaded(true);
         } catch {
             alert("Upload failed for current runtime mode.");
@@ -52,6 +54,7 @@ const App = () => {
     const [selectedPokemon, setSelectedPokemon] = useState(null);
     const [pcInsertTarget, setPcInsertTarget] = useState(null);
     const [refreshKey, setRefreshKey] = useState(0);
+    const [pcBoxId, setPcBoxId] = useState(1);
     const [bagHasUnsavedChanges, setBagHasUnsavedChanges] = useState(false);
 
     const handleTabChange = (nextTab) => {
@@ -330,7 +333,7 @@ const App = () => {
                                 onClick={handleDownload}
                                 className="flex items-center gap-2 bg-blue-600 hover:bg-blue-500 text-white px-4 py-1.5 rounded-full text-xs font-bold transition-all"
                             >
-                                <Save size={14} /> DOWNLOAD .SAV
+                                <Save size={14} /> DOWNLOAD {saveExt.toUpperCase()}
                             </button>
                         </div>
                     )}
@@ -350,14 +353,14 @@ const App = () => {
                             </div>
                             <h2 className="text-2xl md:text-3xl font-bold">Load your Pokemon Unbound save and start editing</h2>
                             <p className="text-slate-300 mt-2 text-sm md:text-base">
-                                Drag and drop a <span className="font-mono">.sav</span> file here, or pick it manually.
+                                Drag and drop a <span className="font-mono">.sav</span> or <span className="font-mono">.srm</span> file here, or pick it manually.
                             </p>
 
                             <div className="mt-5 border border-dashed border-blue-500/40 bg-slate-900/40 rounded-2xl p-5 md:p-6">
                                 <p className="text-xs uppercase tracking-widest text-slate-400 mb-3">Drop zone</p>
                                 <label className="inline-flex bg-blue-600 hover:bg-blue-500 px-6 py-3 rounded-2xl cursor-pointer font-bold transition-all shadow-lg active:scale-95 text-sm">
                                     SELECT SAVE FILE
-                                    <input type="file" className="hidden" onChange={handleUpload} accept=".sav" />
+                                    <input type="file" className="hidden" onChange={handleUpload} accept=".sav,.srm" />
                                 </label>
                             </div>
 
@@ -365,7 +368,7 @@ const App = () => {
                                 Tip: Local mode runs fully in-browser. Backend mode uses FastAPI endpoints.
                             </p>
                             <p className="text-[11px] text-slate-400 mt-1">
-                                Note: You can also try any <span className="font-mono">.sav</span> file from a CFRU + DPE hack.
+                                Note: You can also try any <span className="font-mono">.sav</span> or <span className="font-mono">.srm</span> file from a CFRU + DPE hack.
                             </p>
                         </section>
 
@@ -406,6 +409,8 @@ const App = () => {
                             {activeTab === 'pc' && <PCGrid
                                 key={`pc-${refreshKey}`}
                                 client={client}
+                                boxId={pcBoxId}
+                                onBoxChange={setPcBoxId}
                                 onEditPokemon={(pk) => {
                                     setSelectedPokemon({ ...pk, isPC: true });
                                 }}

--- a/frontend/src/components/PCGrid.jsx
+++ b/frontend/src/components/PCGrid.jsx
@@ -5,8 +5,7 @@ import { POKEMON_ICON_FALLBACK_URL } from '../core/iconResolver.js';
 const TOTAL_BOXES = 26;
 const BOX_SLOTS = 30;
 
-const PCGrid = ({ client, onEditPokemon, onAddPokemon }) => {
-    const [boxId, setBoxId] = useState(1);
+const PCGrid = ({ client, boxId, onBoxChange, onEditPokemon, onAddPokemon }) => {
     const [pokemon, setPokemon] = useState([]);
     const [loading, setLoading] = useState(false);
     const [pcLoaded, setPcLoaded] = useState(false);
@@ -36,11 +35,11 @@ const PCGrid = ({ client, onEditPokemon, onAddPokemon }) => {
     }, [client]);
 
     const handlePrevBox = () => {
-        setBoxId(prev => (prev === 1 ? TOTAL_BOXES : prev - 1));
+        onBoxChange(boxId === 1 ? TOTAL_BOXES : boxId - 1);
     };
 
     const handleNextBox = () => {
-        setBoxId(prev => (prev === TOTAL_BOXES ? 1 : prev + 1));
+        onBoxChange(boxId === TOTAL_BOXES ? 1 : boxId + 1);
     };
 
     const normalizedSlots = Array.from({ length: BOX_SLOTS }, (_, idx) => {


### PR DESCRIPTION
Adds support for .srm save files and fixes PC box navigation resetting after saving edits.

These were two little quirks I found that could be improved, and I figured why not just fix them myself since it's Saturday morning and I'm not doing anything else today.

### .srm file support
- File picker and drag-drop zone now accept .srm files alongside .sav
- The original file extension is preserved on export (uploading a .srm returns a .srm)
- The download button label dynamically reflects the loaded file type (DOWNLOAD .SAV or DOWNLOAD .SRM)
- Backend upload endpoint updated to document .srm acceptance

### PC box state preservation
Previously, editing a Pokemon in the PC and saving would reset the user back to Box 1 regardless of which box they were viewing. This happened because the refreshKey change after save caused React to remount PCGrid, destroying its internal boxId state.

- Lifted boxId state from PCGrid into App so it survives component remounts
- PCGrid now receives boxId and onBoxChange as props
- After saving, the user returns to the same box they were editing in