### PR TITLE
Fix item sector checksum

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1339,7 +1339,7 @@ async def commit_to_file():
     # Pokemon Unbound uses sectors 13, 14, 15, etc. for pockets.
     # Apply checksum recalculation to each bag/PC-items sector.
     for sec in sections:
-        # Sector 13 is the main items sector (fixed 0x454).
+        # Sector 13 is the main items sector (fixed 0x450).
         # Other sectors (Berries, TMs) use standard footer length.
         if sec['id'] >= 13 and sec['id'] <= 16:
             bag_mod.recalculate_checksum(current_save["data"], sec['off'])

--- a/backend/modules/bag.py
+++ b/backend/modules/bag.py
@@ -20,8 +20,9 @@ OFF_SAVE_IDX = 0xFFC
 UNBOUND_ITEM_SECTOR_ID = 13
 # Settori borsa noti (Unbound/CFRU): item, key, balls, berries/tm (varia per build)
 BAG_SECTOR_IDS = {13, 14, 15, 16}
-# Lunghezza fissa trovata col Cracker (0x450 o 0x454 vanno bene, usiamo il max)
-UNBOUND_ITEM_FIXED_LEN = 0x454
+# Correct checksum length for item sector (id=13) is 0x450
+# Using 0x454 includes 4 extra bytes that can be non-zero, producing invalid checksums
+UNBOUND_ITEM_FIXED_LEN = 0x450
 
 # Limiti conservativi per filtro slot borsa
 MAX_PLAUSIBLE_ITEM_ID = 4095

--- a/frontend/src/core/checksum.js
+++ b/frontend/src/core/checksum.js
@@ -8,7 +8,7 @@ import {
 
 const MAX_SECTION_PAYLOAD = 0xFF4;
 const UNBOUND_ITEM_SECTOR_ID = 13;
-const UNBOUND_ITEM_FIXED_LEN = 0x454;
+const UNBOUND_ITEM_FIXED_LEN = 0x450;
 
 export function gbaChecksum(buffer, offset, length) {
     const safeLength = Math.max(0, length);


### PR DESCRIPTION
- Fixes save corruption caused by incorrect checksum length for item sector (section id=13)
- Changed UNBOUND_ITEM_FIXED_LEN from 0x454 to 0x450 in both frontend and backend

The editor was computing the item sector checksum over 0x454 bytes (1108), but the game expects 0x450 bytes (1104). The extra 4 bytes (at offset 0x450–0x453) can contain non-zero data depending on save state.

When those bytes were zero, which happened to be the case on some saves, the wrong length still produced the correct checksum by coincidence (since adding zero doesn't change a sum). When those bytes were non-zero, the editor wrote an incorrect checksum and the game rejected the save as corrupted. :(

This showed up in saves that used Unbound Cloud trading or had been previously edited. Those things didn't cause the issue, but changes in save data and section rotation left non-zero bytes at that offset, exposing the bug